### PR TITLE
Privacy policy: add Connected Services data-handling section

### DIFF
--- a/app/privacy-policy/page.mdx
+++ b/app/privacy-policy/page.mdx
@@ -12,7 +12,7 @@ This is the Privacy Policy **("Policy")** of Hello Identity Co-op (**"Company"**
 
 ## Applicability
 
-This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/) (including any subdomains or mobile versions the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
+This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/), [proxy.aauth.dev](https://proxy.aauth.dev) (including any subdomains or mobile versions the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
 
 ## Agreement
 
@@ -25,6 +25,19 @@ This Policy is referenced in our Terms of Use and capitalized terms not defined 
 We integrate with third party services that provide information used to authenticate your identity (our **"Partners"**).
 
 This Policy reflects only how we process Personal Data through our Service. This Policy does not apply to information processed by our Partners or other third parties, for example, when you create or use Partner accounts, visit a third-party website or interact with third-party services, unless those parties collect or process information on our behalf. Please review any relevant third party's privacy policy for information regarding their privacy practices.
+
+## Connected Services
+
+You may connect third-party services to our Service — for example Google, and other providers we support (each a **"Connected Service"**). When you do, your agents can access your own data at that Connected Service with your consent. We apply the same commitments to the data of every Connected Service, without exception:
+
+- We use it **only** to provide the features you request through the Service.
+- We **do not** transfer or sell it, except as necessary to provide those features, to protect security, or to comply with law.
+- We **do not** use it for advertising.
+- We **do not** use it to train machine learning or AI models.
+- **No human** reads it except with your explicit consent, for security or legal reasons, or in aggregated, anonymized form.
+- We retain the credentials needed to maintain your connection and limited records of requests; we do not warehouse the content we retrieve on your behalf.
+
+For data received from Google APIs, these commitments meet the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy), including the Limited Use requirements; equivalent provider terms apply to other Connected Services.
 
 ## Collection and Use of Personal Data
 


### PR DESCRIPTION
## What

Adds a **Connected Services** section to the privacy policy covering how we handle data from any provider a user connects, and adds `proxy.aauth.dev` to the Applicability domain list.

## Why

The current policy treats Google et al. only as authentication **Partners** — it says nothing about Hellō accessing a user's data *as a client* on their behalf, which is what the Agent Proxy does. Google OAuth verification for sensitive/restricted scopes requires the privacy policy to disclose adherence to the Google API Services User Data Policy, including the **Limited Use** requirements; a policy without it is a documented rejection reason.

## Approach

Rather than a Google-specific clause (which reads as a carve-out implying other services get different treatment), this is a **service-neutral** commitment applying to every "Connected Service" equally — used only to fulfill the user's requests, never sold, never used for advertising or model training, no human access except with consent/security/legal, credentials + limited request records retained but content not warehoused. The Google Limited Use affirmation appears as one bar the universal commitments meet, not a special section.

## Notes

- The "no model training" line is included deliberately — an increasingly common reviewer/user question, cheap to foreclose.
- Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)