### PR TITLE
Remove macron from anchor slugs site-wide

### DIFF
--- a/app/approach/architecture/page.mdx
+++ b/app/approach/architecture/page.mdx
@@ -1,4 +1,4 @@
-# The Hellō Computing Architecture
+# The Hellō Computing Architecture [#the-hello-computing-architecture]
 
 ## Goals
 

--- a/app/approach/cooperative/page.mdx
+++ b/app/approach/cooperative/page.mdx
@@ -7,7 +7,7 @@ To address the governance concerns of a centralized service, Hellō is governed 
 The Hello Identity Co-op has three classes of members: any person using the Hellō service is a member of the user class; any organization can join as a member of the corporate class by executing the corporate membership agreement and paying corporate membership fees; and all Hellō employees are employee members.
 The user and corporate member classes have equal representation with each class electing three directors. Employees are represented by one elected director.
 
-## Hellō Governance
+## Hellō Governance [#hello-governance]
 
 The cooperative's board of directors represents member interests and periodically reviews the Hellō operations to ensure they are meeting the [Hellō Tenets](/approach/tenets), [Laws of Identity](/approach/laws-of-identity), and
 when deployed, the [Data Governance](/approach/data-governance).
@@ -30,6 +30,6 @@ We could not devise a mechanism for developers to be democratically represented.
 
 The corporate membership fees are set by the board to cover the costs of operating the cooperative.
 
-### 4) Why are people using Hellō called "user members"?
+### 4) Why are people using Hellō called "user members"? [#4-why-are-people-using-hello-called-user-members]
 
 They are people that "use" a Hellō Wallet. While there are some negative connotations to the term "user", the term is well understood to mean the person interacting with software.

--- a/app/approach/data-governance/page.mdx
+++ b/app/approach/data-governance/page.mdx
@@ -1,4 +1,4 @@
-# Hellō Data Governance
+# Hellō Data Governance [#hello-data-governance]
 
 ## Privacy is a Human Right
 
@@ -26,15 +26,15 @@ A public ledger is updated with the identity of the law enforcement agency that 
 
 ### FAQs
 
-### 1) What if Hellō is subpoenaed to provide information about a user?
+### 1) What if Hellō is subpoenaed to provide information about a user? [#1-what-if-hello-is-subpoenaed-to-provide-information-about-a-user]
 
 We will educate the requesting party that we do not have the technical capability to provide any information, and share the process for them to access the information.
 
-### 2) What if Hellō's infrastructure vendor (eg AWS) is subpoenaed to exfiltrate user data from machines running one of the components?
+### 2) What if Hellō's infrastructure vendor (eg AWS) is subpoenaed to exfiltrate user data from machines running one of the components? [#2-what-if-hellos-infrastructure-vendor-eg-aws-is-subpoenaed-to-exfiltrate-user-data-from-machines-running-one-of-the-components]
 
 Our understanding of infrastructure vendor functionality is that they are unable to exfiltrate data from a specific running process, and that adding that capability would have the potential to compromise any customer, and they are motivated to deny such a request and succeed. We continue to explore what options we have to ensure that user data cannot be exfiltrated, and welcome suggestions from the community.
 
-### 3) How will Hellō operate in regimes that require access to user information?
+### 3) How will Hellō operate in regimes that require access to user information? [#3-how-will-hello-operate-in-regimes-that-require-access-to-user-information]
 
 We will not operate in those regimes. As Hellō is a global web service, anyone that can connect to Hellō servers can use Hellō, we will not change our data governance to comply with such requests and expect some regimes to block access to Hellō for their citizens.
 

--- a/app/approach/laws-of-identity/page.mdx
+++ b/app/approach/laws-of-identity/page.mdx
@@ -1,4 +1,4 @@
-# Hellō and the Laws of Identity
+# Hellō and the Laws of Identity [#hello-and-the-laws-of-identity]
 
 In 2005, [Kim Cameron](<https://en.wikipedia.org/wiki/Kim_Cameron_(computer_scientist)>) led an industry discussion to create the “[Laws of Identity](https://www.identityblog.com/?p=352)”. One of the [Hellō tenets](/approach/tenets) is to follow these laws. Here is how we comply with each one.
 

--- a/app/approach/page.mdx
+++ b/app/approach/page.mdx
@@ -1,4 +1,4 @@
-# The Hellō Approach
+# The Hellō Approach [#the-hello-approach]
 
 Hellō provides an abstraction layer between identity providers and applications, addressing both personal (B2C) and workforce (B2B) identity challenges. By simplifying integration and enabling a holistic view of user identities, Hellō resolves key issues with both centralized and decentralized approaches to identity.
 
@@ -102,51 +102,51 @@ Hellō bridges the gap between identity providers and applications, solving the 
 
 ## FAQs
 
-### 1) What identity providers does Hellō support?
+### 1) What identity providers does Hellō support? [#1-what-identity-providers-does-hello-support]
 
 Hellō integrates with 30+ providers, including Apple, Google, Facebook, Microsoft, and more. Users can also log in with email, phone, or crypto wallets.
 
-### 2) Why is Hellō's SSO free for developers?
+### 2) Why is Hellō's SSO free for developers? [#2-why-is-hellos-sso-free-for-developers]
 
 Hellō believes basic SSO should be accessible without financial barriers. This approach fosters adoption and builds network effects.
 
-### 3) How does Hellō improve user privacy?
+### 3) How does Hellō improve user privacy? [#3-how-does-hello-improve-user-privacy]
 
 Hellō anonymizes interactions between identity providers and applications, ensuring that neither party learns more about the user than necessary.
 
-### 4) How does Hellō simplify developer workflows?
+### 4) How does Hellō simplify developer workflows? [#4-how-does-hello-simplify-developer-workflows]
 
 Developers integrate with Hellō once and gain access to all supported providers. This eliminates the need for managing multiple APIs or credentials.
 
-### 5) How does Hellō help B2B SaaS developers?
+### 5) How does Hellō help B2B SaaS developers? [#5-how-does-hello-help-b2b-saas-developers]
 
 Hellō provides a single integration point for enterprise identity providers, removing the need to set up and manage individual federations for each enterprise customer.
 
-### 6) What enterprise providers does Hellō support?
+### 6) What enterprise providers does Hellō support? [#6-what-enterprise-providers-does-hello-support]
 
 Hellō currently supports Google Workspace, Microsoft Entra ID, and Zoho, with more providers in the roadmap.
 
-### 7) How is Hellō different from CIAM vendors?
+### 7) How is Hellō different from CIAM vendors? [#7-how-is-hello-different-from-ciam-vendors]
 
 Unlike Auth0 or WorkOS, Hellō does not manage user pools, role-based access, or password-based authentication. Instead, it focuses on being a lightweight, cost-effective SSO abstraction layer.
 
-### 8) Can Hellō handle advanced workforce identity needs?
+### 8) Can Hellō handle advanced workforce identity needs? [#8-can-hello-handle-advanced-workforce-identity-needs]
 
 Yes. Hellō offers premium features like managed apps and de-provisioning for enterprises with mature identity management models.
 
-### 9) Why do enterprises prefer Hellō?
+### 9) Why do enterprises prefer Hellō? [#9-why-do-enterprises-prefer-hello]
 
 Enterprises benefit from simplified SSO setup and a cost-effective solution for managing application access.
 
-### 10) How does supporting both B2C and B2B give Hellō an edge?
+### 10) How does supporting both B2C and B2B give Hellō an edge? [#10-how-does-supporting-both-b2c-and-b2b-give-hello-an-edge]
 
 By addressing both personal and workforce identity, Hellō offers a holistic view of user identity, enabling developers to build richer, more connected experiences.
 
-### 11) How does Hellō support privacy and compliance?
+### 11) How does Hellō support privacy and compliance? [#11-how-does-hello-support-privacy-and-compliance]
 
 Hellō's architecture ensures user data remains private and secure, while its governance model prevents misuse by state or corporate actors.
 
-### 12) Why will users prefer applications that use Hellō?
+### 12) Why will users prefer applications that use Hellō? [#12-why-will-users-prefer-applications-that-use-hello]
 
 Hellō combines the convenience of social logins with enhanced privacy and flexibility. Users avoid vendor lock-in and benefit from a seamless experience across personal and work contexts.
 

--- a/app/approach/protocol/page.mdx
+++ b/app/approach/protocol/page.mdx
@@ -6,7 +6,7 @@ theme:
 import Diagram from '@/components/diagram'
 import { One, Two, Three, Four, Five, Six, Seven, Eight, Nine, Ten } from '@/lib/svg-loader'
 
-# Hellō Protocol
+# Hellō Protocol [#hello-protocol]
 
 The Hellō Protocol ensures that Hellō can not impersonate a user, and that no component can arbitrarily access user data.
 

--- a/app/approach/tenets/page.mdx
+++ b/app/approach/tenets/page.mdx
@@ -1,4 +1,4 @@
-# Hellō Guiding Tenets
+# Hellō Guiding Tenets [#hello-guiding-tenets]
 
 Our tenets guide us in making decisions. When we are choosing between two or more courses of action, we will choose the one that best aligns with our tenets.
 

--- a/app/page.js
+++ b/app/page.js
@@ -145,7 +145,7 @@ export default function Home() {
                     <HelloB2BSSO showTitle={false} compact={true} />
                 </div>
 
-                <div id="hellō-lifecycle" className="px-4 scroll-mt-6">
+                <div id="hello-lifecycle" className="px-4 scroll-mt-6">
                     <h1 className="text-[1.35rem] md:text-4xl font-semibold">Hellō Lifecycle</h1>
                     <h2 className="text-xl md:text-2xl font-medium opacity-65 mt-4">
                         Add offboarding to your B2B app.

--- a/app/products/page.mdx
+++ b/app/products/page.mdx
@@ -15,7 +15,7 @@ import AauthProxy from '@/components/products/aauth-proxy'
 Identity solutions that eliminate complexity and cost. From <span className="text-charcoal/50 dark:text-gray/50 text-[22px] font-semibold">[</span> Free SSO <span className="text-charcoal/50 font-semibold dark:text-gray/50 text-[22px]">]</span> to automated lifecycle management,  
 Hellō abstracts away identity provider complexity through a single OpenID Connect integration.
 
-## Hellō B2C SSO
+## Hellō B2C SSO [#hello-b2c-sso]
 
 ### Give users choice of 17 providers
 
@@ -27,7 +27,7 @@ Hellō abstracts away identity provider complexity through a single OpenID Conne
 
 ---
 
-## Hellō B2B SSO
+## Hellō B2B SSO [#hello-b2b-sso]
 
 ### Zero configuration enterprise SSO
 
@@ -35,7 +35,7 @@ Hellō abstracts away identity provider complexity through a single OpenID Conne
 
 ---
 
-## Hellō Lifecycle
+## Hellō Lifecycle [#hello-lifecycle]
 
 ### Add offboarding to your B2B app
 
@@ -59,7 +59,7 @@ Hellō abstracts away identity provider complexity through a single OpenID Conne
 
 ---
 
-## Hellō AAuth Proxy
+## Hellō AAuth Proxy [#hello-aauth-proxy]
 
 ### Let your agent do real work
 

--- a/app/support/lifecycle/page.mdx
+++ b/app/support/lifecycle/page.mdx
@@ -6,12 +6,12 @@ theme:
 import { Steps } from 'nextra/components'
 import OrgLink from '@/components/org-link'
 
-# Hellō Lifecycle Support
+# Hellō Lifecycle Support [#hello-lifecycle-support]
 
 - [My GitHub org is not showing up during setup](#my-github-org-is-not-showing-up-during-setup)
 - [I changed a user's admin role but Lifecycle doesn't reflect it](#i-changed-a-users-admin-role-but-lifecycle-doesnt-reflect-it)
-- [I want to disconnect my GitHub org from Hellō Lifecycle](#i-want-to-disconnect-my-github-org-from-hellō-lifecycle)
-- [I want to disconnect my organization from Hellō Lifecycle](#i-want-to-disconnect-my-organization-from-hellō-lifecycle)
+- [I want to disconnect my GitHub org from Hellō Lifecycle](#i-want-to-disconnect-my-github-org-from-hello-lifecycle)
+- [I want to disconnect my organization from Hellō Lifecycle](#i-want-to-disconnect-my-organization-from-hello-lifecycle)
 
 ---
 
@@ -51,11 +51,11 @@ Directory providers like Google Workspace and Microsoft Entra do not always send
 
 These changes will be picked up automatically during the daily sync, or you can trigger an immediate sync from your [Hellō Lifecycle dashboard](https://lifecycle.hello.coop) by clicking the **Check Synchronization** button.
 
-## I want to disconnect my GitHub org from Hellō Lifecycle
+## I want to disconnect my GitHub org from Hellō Lifecycle [#i-want-to-disconnect-my-github-org-from-hello-lifecycle]
 
 <Steps>
 
-### Disconnect your GitHub org from the Hellō GitHub Offboarding dashboard
+### Disconnect your GitHub org from the Hellō GitHub Offboarding dashboard [#disconnect-your-github-org-from-the-hello-github-offboarding-dashboard]
 
 1. Go to your [Hellō GitHub Offboarding dashboard](https://lifecycle.hello.coop/github).
 2. Click **Disconnect** next to the GitHub org you want to disconnect.
@@ -65,7 +65,7 @@ This removes the offboarding data for this GitHub org. Automated offboarding wil
 
 You will be prompted to uninstall the GitHub App and delete the repository. If you skipped that step, follow steps 2 or 3 below.
 
-### Uninstall the Hellō Lifecycle GitHub App
+### Uninstall the Hellō Lifecycle GitHub App [#uninstall-the-hello-lifecycle-github-app]
 
 The Hellō Lifecycle GitHub App requires manual removal from your org.
 
@@ -90,11 +90,11 @@ During setup, Hellō Lifecycle created a repository named `Hello-Lifecycle` in y
 
 </Steps>
 
-## I want to disconnect my organization from Hellō Lifecycle
+## I want to disconnect my organization from Hellō Lifecycle [#i-want-to-disconnect-my-organization-from-hello-lifecycle]
 
 <Steps>
 
-### Disconnect your organization from the Hellō Lifecycle dashboard
+### Disconnect your organization from the Hellō Lifecycle dashboard [#disconnect-your-organization-from-the-hello-lifecycle-dashboard]
 
 1. Go to your [Hellō Lifecycle dashboard](https://lifecycle.hello.coop).
 2. Click **Disconnect** next to the organization you want to disconnect.
@@ -104,7 +104,7 @@ This removes all Hellō Lifecycle data for this organization. Automated offboard
 
 You will be prompted to remove access at Google or Microsoft. If you skipped that step, follow step 2 below.
 
-### Revoke Hellō Lifecycle's access to your directory
+### Revoke Hellō Lifecycle's access to your directory [#revoke-hello-lifecycles-access-to-your-directory]
 
 Hellō Lifecycle's directory access requires manual revocation.
 

--- a/app/terms-of-service/page.mdx
+++ b/app/terms-of-service/page.mdx
@@ -103,7 +103,7 @@ All content, copyrights and other intellectual property rights in the content av
 
 Any use of Content on the Service, including without limitation reproduction for purposes other than those noted herein, modification, distribution, replication, any form of data extraction or data mining, or other commercial exploitation of any kind, without prior written permission of an authorized officer of Hellō or as part of a Client agreement with Hellō, is strictly prohibited. You may not make any use of Content owned by any third parties which is available on the Service, without the express consent of those third parties.
 
-### Providing Feedback to Hellō
+### Providing Feedback to Hellō [#providing-feedback-to-hello]
 
 We welcome your comments and feedback about our Service. All information and materials submitted to Hellō through the Service or otherwise, such as any comments, feedback, ideas, questions, designs, data or the like regarding or relating to the Service or the business of Hellō (collectively, **"Feedback"**), will be considered NON-CONFIDENTIAL and NON-PROPRIETARY with regard to you, but Hellō reserves the right to treat any such Feedback as the confidential information of Hellō.
 

--- a/components/products/hello-b2b-sso.js
+++ b/components/products/hello-b2b-sso.js
@@ -1,6 +1,6 @@
 export default function HelloB2BSSO({ showTitle = true, compact = false }) {
     return (
-        <div id="hello-b2c-sso" className="text-[17px]">
+        <div id="hello-b2b-sso" className="text-[17px]">
             {showTitle && (
                 <h1 className="text-[1.35rem] md:text-5xl font-semibold">Hellō B2C SSO</h1>
             )}

--- a/components/products/hello-lifecycle.js
+++ b/components/products/hello-lifecycle.js
@@ -9,7 +9,7 @@ export default function HelloLifecycle({ showTitle = true, compact = false }) {
     useEffect(() => {
         if (typeof window !== 'undefined') {
             const returnUri = encodeURIComponent(
-                `${window.location.origin}${window.location.pathname}#hellō-lifecycle`
+                `${window.location.origin}${window.location.pathname}#hello-lifecycle`
             )
             setWaitlistUrl(
                 `https://wallet.hello.coop/waitlist?waitlist_label=Hell%C5%8D+Lifecycle&return_uri=${returnUri}`

--- a/lib/nav-links.js
+++ b/lib/nav-links.js
@@ -4,17 +4,17 @@ export const navLinks = {
         items: [
             {
                 title: 'Hellō B2C SSO',
-                href: '/products#hellō-b2c-sso',
+                href: '/products#hello-b2c-sso',
                 subtitle: 'Give users choice of 17 providers',
             },
             {
                 title: 'Hellō B2B SSO',
-                href: '/products#hellō-b2b-sso',
+                href: '/products#hello-b2b-sso',
                 subtitle: 'Zero configuration enterprise SSO',
             },
             {
                 title: 'Hellō Lifecycle',
-                href: '/products#hellō-lifecycle',
+                href: '/products#hello-lifecycle',
                 subtitle: 'Add offboarding to your B2B App',
             },
             {
@@ -29,7 +29,7 @@ export const navLinks = {
             },
             {
                 title: 'Hellō AAuth Proxy',
-                href: '/products#hellō-aauth-proxy',
+                href: '/products#hello-aauth-proxy',
                 subtitle: 'Let your agent do real work',
             },
         ],


### PR DESCRIPTION
## Summary
- Headings containing "Hellō" auto-slugged to anchor ids containing the macron (e.g. `#hellō-aauth-proxy`), which turn into ugly percent-encoded fragments like `#hell%C5%8D-aauth-proxy` when copied or shared. Every such heading now declares an explicit ASCII id using Nextra's `## Heading [#custom-id]` syntax — visible heading text is unchanged.
- Updated all fragment references to match: product nav links in `lib/nav-links.js` (used by header, footer, and mobile nav), the in-page TOC links in `app/support/lifecycle/page.mdx`, the waitlist `return_uri` in `components/products/hello-lifecycle.js`, and the home page `hellō-lifecycle` anchor div in `app/page.js`.
- Drive-by fix: `components/products/hello-b2b-sso.js` had a copy-pasted container id (`hello-b2c-sso`); now `hello-b2b-sso`. Nothing referenced the old id.

## Notes
- Old macron links (e.g. from previously shared URLs) will land at the top of the page rather than the section, since fragment navigation is client-side only.
- Verified by rendering all 11 affected pages against the dev server: no `ō` remains in any `id` or fragment `href`, no literal `[#...]` leaks into rendered text, and the support-page TOC links match their heading ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED6LccV1rNuLx8J7sxvSh2