### PR TITLE
Fix copy errors in privacy policy and terms of service

### DIFF
--- a/app/privacy-policy/page.mdx
+++ b/app/privacy-policy/page.mdx
@@ -12,11 +12,11 @@ This is the Privacy Policy **("Policy")** of Hello Identity Co-op (**"Company"**
 
 ## Applicability
 
-This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/), [proxy.aauth.dev](https://proxy.aauth.dev) (including any subdomains or mobile versions the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
+This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/), [proxy.aauth.dev](https://proxy.aauth.dev) (including any subdomains or mobile versions, the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
 
 ## Agreement
 
-This Policy is referenced in our Terms of Use and capitalized terms not defined in this Policy will have the definition provided in the Terms of Use.
+This Policy is referenced in our Terms of Service and capitalized terms not defined in this Policy will have the definition provided in the Terms of Service.
 
 **Your use of our Service indicates your acknowledgement of the practices described in this Policy.**
 
@@ -140,7 +140,7 @@ We, and certain third parties, automatically collect and process Identity Data, 
 Subject to your rights & choices, we may use this information as follows:
 
 1. for “essential” or “functional” purposes, such as to enable certain features of the Service, or keeping you logged in during your session;
-1. for “analytics” and “personalization” purposes, consistent with our business interest in how the Service is used or perform, how users engage with and navigate through our Service, what sites users visit before visiting the Service, how often they visit the Service, and other similar information, as well as to greet users by name and modify the appearance of the Service to usage history, tailor the Service based on geographic location, and understand characteristics of users in various technical and geographic contexts; and
+1. for “analytics” and “personalization” purposes, consistent with our business interest in how the Service is used or performs, how users engage with and navigate through our Service, what sites users visit before visiting the Service, how often they visit the Service, and other similar information, as well as to greet users by name and modify the appearance of the Service to usage history, tailor the Service based on geographic location, and understand characteristics of users in various technical and geographic contexts; and
 
 _Note_: Some of these technologies can be used to identify you across platforms, devices, sites, and services.
 
@@ -160,7 +160,7 @@ We process any Personal Data as is necessary to provide the Service, and as othe
 
 #### Internal Processes and Service Improvement
 
-We may use any Personal Data we process through our Service as necessary in connection with our improvement of the design of our Service, understanding how are Service is used or function, for customer service purposes, in connection with the creation and analysis of logs and metadata relating to service use, and for ensuring the security and stability of the Service. Additionally, we may use Personal Data to understand what parts of our Service are most relevant to users, how users interact with various aspects of our Service, how our Service performs or fails to perform, etc., or we may analyze use of the to determine if there are specific activities that might indicate an information security risk to the Service or our users. This processing is subject to users' rights and choices.
+We may use any Personal Data we process through our Service as necessary in connection with our improvement of the design of our Service, understanding how our Service is used or functions, for customer service purposes, in connection with the creation and analysis of logs and metadata relating to service use, and for ensuring the security and stability of the Service. Additionally, we may use Personal Data to understand what parts of our Service are most relevant to users, how users interact with various aspects of our Service, how our Service performs or fails to perform, etc., or we may analyze use of the Service to determine if there are specific activities that might indicate an information security risk to the Service or our users. This processing is subject to users' rights and choices.
 
 #### Aggregate Analytics
 
@@ -180,7 +180,7 @@ Information we collect may be shared with a variety of parties, depending upon t
 
 ### Service Providers
 
-In connection with our general business operations, product/service improvements, to enable certain features, and in connection with our other lawful business interests, we may share Personal Data with service providers or subprocessors who provide certain services or process data on our behalf. For example, we may use cloud-based hosting providers to host our Service or disclose information as part of our own internal operations, such as security operations, internal research, etc.).
+In connection with our general business operations, product/service improvements, to enable certain features, and in connection with our other lawful business interests, we may share Personal Data with service providers or subprocessors who provide certain services or process data on our behalf. For example, we may use cloud-based hosting providers to host our Service or disclose information as part of our own internal operations, such as security operations, internal research, etc.
 
 ### Corporate Events
 
@@ -192,7 +192,7 @@ In order to streamline certain business operations, share promotions and content
 
 ### Legal Disclosures
 
-In limited circumstances, we may, without notice or your consent, access and disclose your Personal Data, any communications sent or received by you, and any other information that we may have about you to the extent we believe such disclosure is legally required, to prevent or respond to a crime, to investigate violations of our Terms of Use or a Partners agreement, or in the vital interests of us or any person. Note, these disclosures may be made to governments that do not ensure the same degree of protection of your Personal Data as your home jurisdiction. We may, in our sole discretion (but without any obligation), object to the disclosure of your Personal Data to such parties.
+In limited circumstances, we may, without notice or your consent, access and disclose your Personal Data, any communications sent or received by you, and any other information that we may have about you to the extent we believe such disclosure is legally required, to prevent or respond to a crime, to investigate violations of our Terms of Service or a Partners agreement, or in the vital interests of us or any person. Note, these disclosures may be made to governments that do not ensure the same degree of protection of your Personal Data as your home jurisdiction. We may, in our sole discretion (but without any obligation), object to the disclosure of your Personal Data to such parties.
 
 ## Your Rights & Choices
 
@@ -222,7 +222,7 @@ You can delete your profile data at any time by logging into your account at htt
 
 ## Security
 
-We implement and maintain reasonable security measures to safeguard the Personal Data you provide us. However, we sometimes share Personal Data with third parties as noted above, and though we may enter contracts to help ensure security, we do control third parties’ security processes. We do not warrant perfect security and we do not provide any guarantee that your Personal Data or any other information you provide us will remain secure.
+We implement and maintain reasonable security measures to safeguard the Personal Data you provide us. However, we sometimes share Personal Data with third parties as noted above, and though we may enter contracts to help ensure security, we do not control third parties’ security processes. We do not warrant perfect security and we do not provide any guarantee that your Personal Data or any other information you provide us will remain secure.
 
 ## Data Retention
 

--- a/app/terms-of-service/page.mdx
+++ b/app/terms-of-service/page.mdx
@@ -4,7 +4,7 @@ Effective: July 05, 2023
 
 ## Overview
 
-Welcome to Hellō! This service is owned or operated by Hello Identity Co-op (**"Company"**, **"us"**, **"our"**, or **"we"**). These Terms of Service (**"Terms"**) set forth the terms and conditions under which you, and any entity on whose behalf you enter into these Terms (including its authorized users, **"Customer"**) (collectively, **"you"** or **"your"**) are authorized to use our Service. Our **"Service"** includes our website located at www.hello.coop or other websites where these Terms are posted (**"Site"**), our cloud-based software application and service, and any of our mobile applications ("Apps")
+Welcome to Hellō! This service is owned or operated by Hello Identity Co-op (**"Company"**, **"us"**, **"our"**, or **"we"**). These Terms of Service (**"Terms"**) set forth the terms and conditions under which you, and any entity on whose behalf you enter into these Terms (including its authorized users, **"Customer"**) (collectively, **"you"** or **"your"**) are authorized to use our Service. Our **"Service"** includes our website located at www.hello.coop or other websites where these Terms are posted (**"Site"**), our cloud-based software application and service, and any of our mobile applications ("Apps").
 
 **Through your use of our Service or otherwise accepting these Terms, you acknowledge our Privacy Policy, and agree to these Terms.**
 
@@ -26,7 +26,7 @@ Either party may terminate the Agreement (i) if the other party breaches its mat
 
 Hellō may at any time, and in Hellō’s sole discretion, discontinue the Service or modify the Service, and such action by Hellō may adversely affect the use of the Service. Hellō shall not be liable to you or to any third party for any modification, suspension, or discontinuance of the Service, provided that we will refund any prepaid amounts if we discontinue the Service in its entirety prior to the end of the Term. Hellō shall use reasonable efforts to notify users of the cessation of the Service or any changes that would affect Your use of the Service. Hellō may give such notices through the Service or on its website or by email communications.
 
-You acknowledge that removing the our App from your mobile phone does not automatically terminate your rights to use the Service, close your account, or terminated this Agreement or any Order Term.
+You acknowledge that removing our App from your mobile phone does not automatically terminate your rights to use the Service, close your account, or terminate this Agreement or any Order Term.
 
 Upon your request that your use of the Service be terminated:
 
@@ -81,7 +81,7 @@ Further, without our written consent, you may not:
 
 ## Disclaimer Of Warranties And Limitation Of Liability
 
-TO THE FULLEST EXTENT PERMITTED BY LAW, HELLO IDENTITY CO-OP, ITS RELATED ENTITIES, ITS SERVICE PROVIDERS, PARTERNS, LICENSORS, AND ITS OR THEIR RESPECTIVE OFFICERS, DIRECTORS, EMPLOYEES OR AGENTS (COLLECTIVELY THE “COMPANY PARTIES”) EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, RELATED TO OUR SERVICES.
+TO THE FULLEST EXTENT PERMITTED BY LAW, HELLO IDENTITY CO-OP, ITS RELATED ENTITIES, ITS SERVICE PROVIDERS, PARTNERS, LICENSORS, AND ITS OR THEIR RESPECTIVE OFFICERS, DIRECTORS, EMPLOYEES OR AGENTS (COLLECTIVELY THE “COMPANY PARTIES”) EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, RELATED TO OUR SERVICES.
 
 YOU UNDERSTAND AND AGREE THAT YOUR USE OF OUR SERVICES IS AT YOUR SOLE RISK. OUR SERVICE AND ALL CONTENT, PRODUCTS AND SERVICES OFFERED THROUGH THE SERVICES ARE PROVIDED ON AN "AS IS", "AS AVAILABLE" AND “WITH ALL FAULTS” BASIS. THE COMPANY PARTIES ARE NOT RESPONSIBLE FOR THE TIMELINESS OF DELIVERY OF CONTENT, ANY FAILURES OF DELIVERY, ERRONEOUS DELETION, OR ANY LOSS OR DAMAGE OF ANY KIND YOU CLAIM WAS INCURRED AS A RESULT OF THE USE OF ANY SERVICES. UNDER NO CIRCUMSTANCES, WILL ANY OF THE COMPANY PARTIES BE LIABLE TO YOU OR TO ANY PERSON OR ENTITY CLAIMING THROUGH YOU FOR ANY LOSS, INJURY, LIABILITY OR DAMAGES ARISING OUT OF OR IN CONNECTION WITH YOUR ACCESS TO, USE OF, INABILITY TO USE, OR RELIANCE ON ANY OF OUR SERVICES OR ANY CONTENT, PRODUCT OR SERVICE PROVIDED TO YOU THROUGH OR IN CONNECTION WITH ANY OF OUR SERVICES. THIS IS A COMPREHENSIVE LIMITATION OF LIABILITY THAT APPLIES TO ALL LOSSES AND DAMAGES OF ANY KIND WHATSOEVER, WHETHER DIRECT OR INDIRECT, GENERAL, SPECIAL, INCIDENTAL, CONSEQUENTIAL, EXEMPLARY OR OTHERWISE, INCLUDING WITHOUT LIMITATION, LOSS OF DATA, GOODWILL, REVENUE OR PROFITS. THIS LIMITATION OF LIABILITY APPLIES WHETHER THE ALLEGED LIABILITY IS BASED ON CONTRACT, NEGLIGENCE, TORT, STRICT LIABILITY OR ANY OTHER BASIS; EVEN IF ANY COMPANY PARTY HAS BEEN ADVISED OF OR SHOULD HAVE KNOWN OF THE POSSIBILITY OF SUCH DAMAGES; AND WITHOUT REGARD TO THE SUCCESS OR EFFECTIVENESS OF OTHER REMEDIES. IF ANY PART OF THIS LIMITATION OF LIABILITY IS FOUND TO BE INVALID, ILLEGAL OR UNENFORCEABLE FOR ANY REASON, THEN THE AGGREGATE LIABILITY OF THE COMPANY PARTIES UNDER SUCH CIRCUMSTANCES TO YOU OR ANY PERSON OR ENTITY CLAIMING THROUGH YOU FOR LIABILITIES THAT OTHERWISE WOULD HAVE BEEN LIMITED WILL NOT EXCEED ONE HUNDRED U.S. DOLLARS.
 
@@ -115,9 +115,9 @@ The interpretation of the rights and obligations of the parties under this Agree
 
 ### Dispute Resolution
 
-By entering into Terms of Service, you hereby irrevocably waive any right you may have to join claims with those of others in the form of a class action or similar procedural device. Any claims arising out of, relating to, or connected with these Terms of Service must be asserted individually.
+By entering into these Terms of Service, you hereby irrevocably waive any right you may have to join claims with those of others in the form of a class action or similar procedural device. Any claims arising out of, relating to, or connected with these Terms of Service must be asserted individually.
 
-You acknowledge and agree that, regardless of any statute or law to the contrary, any claim or cause of action you may have arising out of, relating to, or connected with your use of the Service must be filled within one calendar year after such claim or cause of action arises, or forever be barred. If a claim proceeds in court, we each waive any right to a jury trial.
+You acknowledge and agree that, regardless of any statute or law to the contrary, any claim or cause of action you may have arising out of, relating to, or connected with your use of the Service must be filed within one calendar year after such claim or cause of action arises, or forever be barred. If a claim proceeds in court, we each waive any right to a jury trial.
 
 ### Compliance with Laws
 
@@ -137,7 +137,7 @@ We reserve the right, at any time, to modify, alter, or update these Terms witho
 
 **Assignment** - These Terms of Service will be binding upon each party hereto and its successors and permitted assigns. These Terms of Service are not assignable or transferable by you without the prior written consent of Hellō. You agree that these Terms of Service and any other agreements referenced herein may be assigned by us, in our sole discretion, to a third party in the event of a merger or acquisition, or otherwise.
 
-**Third Party Beneficiaries** - You acknowledge that Apple and Google are intended third party beneficiaries of your releases, waivers, and covenants in the Apple Required Terms and in the Additional Terms Required by Google, Inc., respectively. Subject to the foregoing, nothing in this agreement is intended to confer any right, remedy, cause of action or liability on any person other than rain and its successors and assigns and you.
+**Third Party Beneficiaries** - You acknowledge that Apple and Google are intended third party beneficiaries of your releases, waivers, and covenants in the Apple Required Terms and in the Additional Terms Required by Google, Inc., respectively. Subject to the foregoing, nothing in this agreement is intended to confer any right, remedy, cause of action or liability on any person other than Hellō and its successors and assigns and you.
 
 **Integration** - These Terms of Service (including all Additional Agreements and other policies or terms incorporated herein) contain the entire understanding of the parties regarding its subject matter, and supersedes all prior and contemporaneous agreements and understandings between the parties regarding its subject matter.
 
@@ -176,7 +176,7 @@ Feel free to contact us with questions or concerns about these Terms using the a
 
 **Legal Compliance** - You represent and warrant that (i) You are not located in a country that is subject to a U.S. Government embargo, or that has been designated by the U.S. Government as a country or territory that is subject to a sanctions program (e.g., designated by OFAC); and (ii) You are not identified on any list prepared by the U.S. Government describing prohibited or restricted parties.
 
-**Developer Name and Address** - Hellō may be contacted at in connection with any questions, complaints or claims with respect to the Service.
+**Developer Name and Address** - Hellō may be contacted at contact@hello.coop in connection with any questions, complaints or claims with respect to the Service.
 
 **Third Party Beneficiary** - Hellō and You acknowledge and agree that Apple, and Apple’s subsidiaries, are third party beneficiaries of the Terms of Service, and that, upon Your acceptance of the Terms of Service, Apple will have the right (and will be deemed to have accepted the right) to enforce the Terms of Service against You as a third party beneficiary thereof.
 


### PR DESCRIPTION
Copy/correctness fixes to the Privacy Policy and Terms of Service, surfaced while reviewing them for the Google OAuth verification of the AAuth Proxy.

## Privacy Policy
- **Security section — meaning inversion:** "we do control third parties' security processes" → "we do **not** control…" (the missing "not" contradicted the rest of the section).
- **Internal Processes:** "how **are** Service is used or **function**" → "how **our** Service is used or **functions**"; "analyze use of **the** to determine" → "analyze use of **the Service** to determine".
- "or perform" → "or performs"; removed a stray unmatched ")"; added a missing comma before "Site".
- **"Terms of Use" → "Terms of Service"** — the policy referenced a document by a name that doesn't exist on the site.

## Terms of Service
- **Removed leftover "rain" template placeholder** → "Hellō" (Third Party Beneficiaries).
- "the our App" → "our App"; "or terminated this Agreement" → "or terminate…".
- "PARTERNS" → "PARTNERS"; "filled within one calendar year" → "filed…".
- **Filled the blank "Developer Name and Address" contact** → contact@hello.coop.
- "By entering into Terms of Service" → "these Terms of Service"; added a missing sentence-ending period.

No layout or structural changes — copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5aU3Qb7ptyzvunw2oQLrx
