### PR TITLE
Privacy policy: state what Connected Service data agents can reach

### DIFF
--- a/app/privacy-policy/page.mdx
+++ b/app/privacy-policy/page.mdx
@@ -28,7 +28,7 @@ This Policy reflects only how we process Personal Data through our Service. This
 
 ## Connected Services
 
-You may connect third-party services to our Service — for example Google, and other providers we support (each a **"Connected Service"**). When you do, your agents can access your own data at that Connected Service with your consent. We apply the same commitments to the data of every Connected Service, without exception:
+You may connect third-party services to our Service — for example Google, and other providers we support (each a **"Connected Service"**). When you do, your agents can access your own data at that Connected Service with your consent — limited to the operations you authorize. Depending on the service and what you have authorized, that can include email and messages, calendar events, contacts, files and documents, chat messages, task lists, and reporting or analytics data. We apply the same commitments to the data of every Connected Service, without exception:
 
 - We use it **only** to provide the features you request through the Service.
 - We **do not** transfer or sell it, except as necessary to provide those features, to protect security, or to comply with law.


### PR DESCRIPTION
## What

Adds the data categories to the **Connected Services** section, and makes explicit that access is bounded by the operations the person authorizes.

**Before**
> When you do, your agents can access your own data at that Connected Service with your consent.

**After**
> When you do, your agents can access your own data at that Connected Service with your consent — limited to the operations you authorize. Depending on the service and what you have authorized, that can include email and messages, calendar events, contacts, files and documents, chat messages, task lists, and reporting or analytics data.

## Why

Google's OAuth verification checklist has a **Data Access** requirement: the privacy policy must state what user data the app accesses. The section covered Use, Transfer, Protection, Retention, AI/ML, and the Google API Limited Use commitment — but on access itself it said only that access happens and that the person consented.

Kept provider-neutral rather than enumerating Google-specific data:

- the section applies one set of commitments to every Connected Service, so a Google-only list would sit oddly and need editing as adapters ship;
- access is determined per-person by what they authorize, so a fixed enumeration would overstate what is reached;
- the authoritative statement of exactly what may be accessed is the OAuth scope list declared in the Cloud Console.

The categories map to the shipped AAuth Proxy adapters: email and messages → Gmail, Chat; calendar events → Calendar, Meet; contacts → People; files and documents → Docs, Sheets, Slides, Forms; task lists → Tasks; reporting or analytics → Search Console, Analytics, YouTube Analytics.

No other text changes — the six commitment bullets and the Google API Limited Use line are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9cjwXkCRqGkihB5vFf3Zb