### PR TITLE
Add person.hello.coop to privacy policy Applicability list

### DIFF
--- a/app/privacy-policy/page.mdx
+++ b/app/privacy-policy/page.mdx
@@ -12,7 +12,7 @@ This is the Privacy Policy **("Policy")** of Hello Identity Co-op (**"Company"**
 
 ## Applicability
 
-This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/), [proxy.aauth.dev](https://proxy.aauth.dev) (including any subdomains or mobile versions, the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
+This Policy applies to our **"Service"** which include our websites at [hello.coop](https://www.hello.coop), [hello.dev](https://www.hello.dev), [wallet.hello.coop](https://wallet.hello.coop), [person.hello.coop](https://person.hello.coop), [console.hello.coop](https://console.hello.coop), [quickstart.hello.coop](https://quickstart.hello.coop), [playground.hello.dev](https://playground.hello.dev), [greenfielddemo.com](https://www.greenfielddemo.com/), [proxy.aauth.dev](https://proxy.aauth.dev) (including any subdomains or mobile versions, the **"Site"**), our cloud-based software application and service, and any of our mobile applications (**"Apps"**).
 
 ## Agreement
 


### PR DESCRIPTION
`person.hello.coop` is a user-facing origin — the AAuth Person Server SPA runs there, and login flows now complete on that origin rather than bouncing back to `wallet.hello.coop`. It was missing from the Applicability list of sites the policy covers.

Added it immediately after `wallet.hello.coop`, since the two are paired origins for the same service.

Found while adding `person.*` OAuth redirect URIs across all identity providers in the Wallet repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c6SWnbNbAqmLEPqnnCMo5